### PR TITLE
Context database bug

### DIFF
--- a/pypcode/__init__.py
+++ b/pypcode/__init__.py
@@ -320,7 +320,7 @@ class SeqNum(ContextObj):
   uniq: int
   order: int
 
-  def __init__(self, ctx:Context, pc:AddrSpace, uniq:int, order:int):
+  def __init__(self, ctx:Context, pc:Address, uniq:int, order:int):
     super().__init__(ctx)
     self.pc = pc
     self.uniq = uniq


### PR DESCRIPTION
Hi!

While using this wonderful library to process some ARM binaries, I encountered an unhandled `LowLevelError` exception when translating snippets that had ARM/thumb mode switches in them.

This is enough to trigger it.
```python
import pypcode
langs = {l.id:l for arch in pypcode.Arch.enumerate() for l in arch.languages}
ctx = pypcode.Context(langs['ARM:LE:32:v8T'])

arm_snippet = b'\xff\xf7\xbe\xe9'     # blx <rel-addr> (with switch to ARM)

# translates fine, but ContextInternal instance has new entry for "TMode" context register
ctx.translate(arm_snippet, 0x1000, max_inst=1)

# during Sleigh->initialize() when resetting ContextInternal's symbol table
# ContextInternal::registerVariable() throws exception
ctx.translate(arm_snippet, 0x1000, max_inst=1)
```

After spending time digging into the sleigh code base, it looks to me like `ContextInternal` was never designed with the intention to be reset. `Sleigh::reset(LoadImage *ld,ContextDatabase *c_db)` just merely assigns the `LoadImage` and `ContextDatabase` to the engine, and creates new context and disassembly caches.

In `ContextInternal::registerVariable()`, the exception is thrown whenever `ContextInternal::database` is non-empty. So it's supposed to be fresh for each call to `Sleigh::reset()`. 

There were a few ways I thought it could be addressed. Simply recreate a new instance of `ContextInternal` for every call to `TranslationContext::translate()` but I thought that would be a bit clunky. Another was to define a new `ContextDatabase` implementation that handles resetting but then we're missing out on the ready functionality of `ContextInternal`. The last way which I opted for at the moment is subclassing `ContextInternal` and working around the exception issue by only registering variables if we're in a fresh state and ignoring them during subsequent resets. I also implemented resetting the context variables to their default values for every call to `translate()`.

Let me know what seems best and I'll make any necessary changes.

Thanks for this great library!