### PR TITLE
Fix CI build, update wheel list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,11 @@ jobs:
           - { os: ubuntu-latest,  wheel: cp37-manylinux_x86_64 }
 
           - { os: macos-latest,   wheel: pp37-macosx_x86_64 }
+          - { os: windows-latest, wheel: pp37-win_amd64 }
           - { os: ubuntu-latest,  wheel: pp37-manylinux_x86_64 }
 
           - { os: macos-latest,   wheel: pp38-macosx_x86_64 }
+          - { os: windows-latest, wheel: pp38-win_amd64 }
           - { os: ubuntu-latest,  wheel: pp38-manylinux_x86_64 }
 
           - { os: macos-latest,   wheel: cp38-macosx_x86_64 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: macos-latest,   wheel: cp36-macosx_x86_64 }
-          - { os: windows-latest, wheel: cp36-win_amd64 }
-          - { os: windows-latest, wheel: cp36-win32 }
-          - { os: ubuntu-latest,  wheel: cp36-manylinux_x86_64 }
-
           - { os: macos-latest,   wheel: cp37-macosx_x86_64 }
           - { os: windows-latest, wheel: cp37-win_amd64 }
           - { os: windows-latest, wheel: cp37-win32 }
@@ -39,14 +34,14 @@ jobs:
           - { os: windows-latest, wheel: pp37-win_amd64 }
           - { os: ubuntu-latest,  wheel: pp37-manylinux_x86_64 }
 
-          - { os: macos-latest,   wheel: pp38-macosx_x86_64 }
-          - { os: windows-latest, wheel: pp38-win_amd64 }
-          - { os: ubuntu-latest,  wheel: pp38-manylinux_x86_64 }
-
           - { os: macos-latest,   wheel: cp38-macosx_x86_64 }
           - { os: windows-latest, wheel: cp38-win_amd64 }
           - { os: windows-latest, wheel: cp38-win32 }
           - { os: ubuntu-latest,  wheel: cp38-manylinux_x86_64 }
+
+          - { os: macos-latest,   wheel: pp38-macosx_x86_64 }
+          - { os: windows-latest, wheel: pp38-win_amd64 }
+          - { os: ubuntu-latest,  wheel: pp38-manylinux_x86_64 }
 
           - { os: macos-latest,   wheel: cp39-macosx_x86_64 }
           - { os: windows-latest, wheel: cp39-win_amd64 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Unpack source distribution
         run: tar -xf ${{ env.PKG }}.tar.gz
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.10.0
+        run: python -m pip install cibuildwheel==2.3.1
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse ${{ env.PKG }}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,9 @@ jobs:
           - { os: ubuntu-latest,  wheel: cp37-manylinux_x86_64 }
 
           - { os: macos-latest,   wheel: pp37-macosx_x86_64 }
-          - { os: windows-latest, wheel: pp37-win32 }
           - { os: ubuntu-latest,  wheel: pp37-manylinux_x86_64 }
 
           - { os: macos-latest,   wheel: pp38-macosx_x86_64 }
-          - { os: windows-latest, wheel: pp38-win32 }
           - { os: ubuntu-latest,  wheel: pp38-manylinux_x86_64 }
 
           - { os: macos-latest,   wheel: cp38-macosx_x86_64 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
           - { os: windows-latest, wheel: pp37-win32 }
           - { os: ubuntu-latest,  wheel: pp37-manylinux_x86_64 }
 
+          - { os: macos-latest,   wheel: pp38-macosx_x86_64 }
+          - { os: windows-latest, wheel: pp38-win32 }
+          - { os: ubuntu-latest,  wheel: pp38-manylinux_x86_64 }
+
           - { os: macos-latest,   wheel: cp38-macosx_x86_64 }
           - { os: windows-latest, wheel: cp38-win_amd64 }
           - { os: windows-latest, wheel: cp38-win32 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,6 @@ jobs:
           - { os: windows-latest, wheel: cp36-win32 }
           - { os: ubuntu-latest,  wheel: cp36-manylinux_x86_64 }
 
-          - { os: macos-latest,   wheel: pp36-macosx_x86_64 }
-          - { os: windows-latest, wheel: pp36-win32 }
-          - { os: ubuntu-latest,  wheel: pp36-manylinux_x86_64 }
-
           - { os: macos-latest,   wheel: cp37-macosx_x86_64 }
           - { os: windows-latest, wheel: cp37-win_amd64 }
           - { os: windows-latest, wheel: cp37-win32 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,11 @@ jobs:
           - { os: windows-latest, wheel: cp39-win32 }
           - { os: ubuntu-latest,  wheel: cp39-manylinux_x86_64 }
 
+          - { os: macos-latest,   wheel: cp310-macosx_x86_64 }
+          - { os: windows-latest, wheel: cp310-win_amd64 }
+          - { os: windows-latest, wheel: cp310-win32 }
+          - { os: ubuntu-latest,  wheel: cp310-manylinux_x86_64 }
+
     steps:
       - uses: actions/setup-python@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cffi >= 1.15.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
+import os
 from setuptools import setup, find_packages
-from build_cffi import FfiPreBuildExtension
-import os, os.path
+import sys
+
+sys.path.append(os.getcwd())
+import build_cffi
 
 def add_pkg_data_dirs(pkg, dirs):
 	pkg_data = []
@@ -27,6 +30,6 @@ setup(name='pypcode',
 	setup_requires=['cffi'],
 	install_requires=['cffi'],
 	cffi_modules=['build_cffi.py:ffibuilder'],
-	cmdclass={'build_ext': FfiPreBuildExtension},
+	cmdclass={'build_ext': build_cffi.FfiPreBuildExtension},
 	python_requires='>=3.6'
 	)


### PR DESCRIPTION
* Updates cibuildwheel
* Drops CPython/PyPy 3.6
* Adds PyPy 3.8
* Adds CPython 3.10
* Moves Windows PyPy 32b -> 64b
* Adds basic pyproject.toml
