### PR TITLE
added mutexes to xml globals

### DIFF
--- a/pypcode/native/sleigh/xml.cc
+++ b/pypcode/native/sleigh/xml.cc
@@ -97,6 +97,8 @@
 
 #include <iostream>
 #include <string>
+#include <mutex>
+#include <thread>
 
 string Attributes::bogus_uri("http://unused.uri");
 
@@ -186,6 +188,8 @@ extern int4 convertEntityRef(const string &ref);	///< Convert an XML entity to i
 extern int4 convertCharRef(const string &ref);	///< Convert an XML character reference to its equivalent character
 static XmlScan *global_scan;					///< Global reference to the scanner
 static ContentHandler *handler;					///< Global reference to the content handler
+static std::mutex global_scan_mutex;
+static std::mutex handler_mutex;
 extern int yydebug;								///< Debug mode
 
 #line 177 "src/decompile/cpp/xml.cc" /* yacc.c:339  */
@@ -2239,6 +2243,8 @@ int4 xml_parse(istream &i,ContentHandler *hand,int4 dbg)
 #if YYDEBUG
   yydebug = dbg;
 #endif
+  std::lock_guard<std::mutex> global_scan_lock(global_scan_mutex);
+  std::lock_guard<std::mutex> handler_lock(handler_mutex);
   global_scan = new XmlScan(i);
   handler = hand;
   handler->startDocument();

--- a/pypcode/native/sleigh/xml.y
+++ b/pypcode/native/sleigh/xml.y
@@ -24,6 +24,8 @@
 
 #include <iostream>
 #include <string>
+#include <mutex>
+#include <thread>
 
 string Attributes::bogus_uri("http://unused.uri");
 
@@ -113,6 +115,8 @@ extern int4 convertEntityRef(const string &ref);	///< Convert an XML entity to i
 extern int4 convertCharRef(const string &ref);	///< Convert an XML character reference to its equivalent character
 static XmlScan *global_scan;					///< Global reference to the scanner
 static ContentHandler *handler;					///< Global reference to the content handler
+static std::mutex global_scan_mutex;
+static std::mutex handler_mutex;
 extern int yydebug;								///< Debug mode
 %}
 
@@ -517,6 +521,8 @@ int4 xml_parse(istream &i,ContentHandler *hand,int4 dbg)
 #if YYDEBUG
   yydebug = dbg;
 #endif
+  std::lock_guard<std::mutex> global_scan_lock(global_scan_mutex);
+  std::lock_guard<std::mutex> handler_lock(handler_mutex);
   global_scan = new XmlScan(i);
   handler = hand;
   handler->startDocument();


### PR DESCRIPTION
On the call-path from `m_document = m_document_storage.openDocument(path);` in `sleigh/xml.cc::xml_parse()`, the global variables `global_scan` and `handler` are set and used to perform the xml parsing. This is problematic in a multithreaded environment because both variables are modified without a thread locking mechanism.

Using `pypcode` with an additional thread will result in a SIGSEGV or SIGABRT when loading the sla file.

This fix is ported from the [sleighcraft](https://github.com/StarCrossPortal/sleighcraft/blob/master/sleighcraft/src/cpp/gen/bison/xml.cpp) project. 

I will duplicate this fix in a PR to upstream ghidra and track it here as well.

A POC for reproducing the crash is below. I've tested on my local `pypcode` version 1.0.2.

```python
"""
Test the pypcode sleigh bindings in a multithreaded environment.
"""
import logging
import threading

from pypcode import Arch, Context

logger = logging.getLogger(__name__)
logger.setLevel(logging.DEBUG)


def get_pcode(lang_id: str = "MIPS:LE:32:default"):
    """
    :param lang_id: a string that identifies the architecture, endianness, and
        bits of the code. See 'python3 -m pypcode -l' for a list of lang_ids.
    """
    langs = {l.id:l for arch in Arch.enumerate() for l in arch.languages}
    context = Context(langs[lang_id])


def main():
    t1 = threading.Thread(target=get_pcode, args=())
    t2 = threading.Thread(target=get_pcode, args=())
    t1.start()
    t2.start()

    t1.join()
    t2.join()
    print("done")

if __name__ == "__main__":
    main()

"""
user@pc:~/test$ python test_pypcode_multithreaded.py
Segmentation fault                                                        
user@pc:~/test$ python test_pypcode_multithreaded.py
terminate called after throwing an instance of 'XmlError'
terminate called recursively
Aborted
"""
```