### PR TITLE
Catch DecodeError during context creation

### DIFF
--- a/pypcode/__init__.py
+++ b/pypcode/__init__.py
@@ -331,6 +331,12 @@ class Arch:
                 yield Arch(archname, ldefpath)
 
 
+class ContextCreationError(Exception):
+    """
+    An error during context creation.
+    """
+
+
 class Context:
     """
     Context for translation.
@@ -351,6 +357,8 @@ class Context:
         self._cached_addr_spaces = {}
         self.lang = lang
         self.ctx_c = csleigh_createContext(self.lang.slafile_path.encode("utf-8"))
+        if not self.ctx_c:
+            raise ContextCreationError()
         self.lang.init_context_from_pspec(self.ctx_c)
 
         count_a = ffi.new("unsigned int *count")

--- a/pypcode/native/csleigh.cc
+++ b/pypcode/native/csleigh.cc
@@ -256,10 +256,13 @@ public:
         ElementId::initialize();
 
         LOG("%p Loading slafile...", this);
-        // FIXME: try/catch XmlError
-        m_document = m_document_storage.openDocument(path);
-        m_tags = m_document->getRoot();
-        m_document_storage.registerTag(m_tags);
+        try {
+            m_document = m_document_storage.openDocument(path);
+            m_tags = m_document->getRoot();
+            m_document_storage.registerTag(m_tags);
+        } catch (DecoderError &e) {
+            return false;
+        }
 
         LOG("Setting up translator");
         m_sleigh.reset(new Sleigh(&m_loader, &m_context_db));

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,13 +3,19 @@
 
 from unittest import main, TestCase
 
-from pypcode import ArchLanguage, Context
+from pypcode import ArchLanguage, Context, ContextCreationError
 
 
 class Tests(TestCase):
     """
     Basic tests
     """
+
+    def test_failed_context_creation(self):
+        lang = ArchLanguage.from_id("x86:LE:64:default")
+        bad_lang = ArchLanguage("/bad/arch/path", lang.ldef)
+        with self.assertRaises(ContextCreationError):
+            Context(bad_lang)
 
     def test_x86_64_translation(self):
         lang = ArchLanguage.from_id("x86:LE:64:default")


### PR DESCRIPTION
Error messaging can be improved, but this works for now.

Fixes #37 