### PR TITLE
Use stable ABI for Python 3.12+ wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
-        py: [cp310, cp311, cp312, cp313]
+        py: [cp310, cp311, cp312]
         platform:
           - { arch: x86_64,  os: windows-latest,   wheel_tag: win_amd64         }
           - { arch: x86_64,  os: macos-13,         wheel_tag: macosx_x86_64     }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: |
-          python -m pip install pylint wheel
-          python -m pip install -e .
+          python -m pip install -e .[pylint]
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: pylint --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: |
-          python -m pip install pylint
+          python -m pip install pylint wheel
           python -m pip install -e .
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,35 @@ jobs:
           name: ${{ matrix.py }}-${{ matrix.platform.wheel_tag }}
           path: ./wheelhouse/*.whl
 
+  test_abi3_wheels:
+    needs: build_wheels
+    name: Test with Python ${{ matrix.py }} on ${{ matrix.platform.os }}
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      matrix:
+        py: [ "3.13" ]
+        platform:
+          - { arch: x86_64,  os: windows-latest,   wheel_tag: win_amd64         }
+          - { arch: x86_64,  os: macos-13,         wheel_tag: macosx_x86_64     }
+          - { arch: arm64,   os: macos-latest,     wheel_tag: macosx_arm64      }
+          - { arch: x86_64,  os: ubuntu-latest,    wheel_tag: manylinux_x86_64  }
+          - { arch: aarch64, os: ubuntu-24.04-arm, wheel_tag: manylinux_aarch64 }
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Unpack source distribution
+        shell: bash
+        run: tar --strip-components 1 -xvf artifacts/*.tar.gz
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Install wheel and run tests
+        run: |
+          python -m pip install --no-index --find-links=artifacts pypcode
+          cd tests; python -m unittest discover -v .
+
   build_docs:
     name: Build docs
     runs-on: ubuntu-latest
@@ -87,7 +116,7 @@ jobs:
 
   upload_pypi:
     name: Upload wheels to PyPI
-    needs: [lint, build_docs, build_sdist, build_wheels]
+    needs: [lint, build_docs, build_sdist, build_wheels, test_abi3_wheels]
     environment:
       name: pypi
       url: https://pypi.org/p/pypcode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(sleigh
 install(TARGETS sleigh DESTINATION bin)
 
 nanobind_add_module(pypcode_native
+  STABLE_ABI
   pypcode/pypcode_native.cpp
   ${SLEIGH_COMMON}
   ${ZLIB}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
 ]
+pylint = [ "pylint", "wheel" ]
 
 [build-system]
 requires = [ "setuptools", "nanobind", "cmake", "wheel" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ docs = [
 ]
 
 [build-system]
-requires = [ "setuptools", "nanobind", "cmake" ]
+requires = [ "setuptools", "nanobind", "cmake", "wheel" ]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,22 @@ import subprocess
 import sys
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
+from wheel.bdist_wheel import bdist_wheel
+
+
+class bdist_wheel_abi3(bdist_wheel):
+    """
+    Overrides bdist_wheel to provide stable ABI platform tag.
+    """
+
+    def get_tag(self):
+        python, abi, plat = super().get_tag()
+
+        if python.startswith("cp") and sys.version_info >= (3, 12):
+            # on CPython, our wheels are abi3 and compatible back to 3.12
+            return "cp312", "abi3", plat
+
+        return python, abi, plat
 
 
 class BuildExtension(build_ext):
@@ -99,5 +115,5 @@ setup(
     package_data={
         "pypcode": add_pkg_data_dirs("pypcode", ["bin", "docs", "processors"]) + ["py.typed", "pypcode_native.pyi"]
     },
-    cmdclass={"build_ext": BuildExtension},
+    cmdclass={"build_ext": BuildExtension, "bdist_wheel": bdist_wheel_abi3},
 )


### PR DESCRIPTION
Closes #134 

---

Leaving as draft for now. Apparently there are still issues with nanobind's stable ABI and Python 3.13:
* https://github.com/wjakob/nanobind/discussions/1076
* https://github.com/wjakob/nanobind/discussions/1047
