### PR TITLE
pyproject.toml: Align with current license metadata guidance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "pypcode"
 description = "Machine code disassembly and IR translation library"
-license = { file = "LICENSE.txt" }
+license = "BSD-2-Clause AND Apache-2.0 AND Zlib"
+license-files = [ "LICENSE.txt" ]
 readme = { file = "README.md", content-type = "text/markdown" }
 classifiers = [
     "Programming Language :: Python",


### PR DESCRIPTION
```
DEBUG         ********************************************************************************
DEBUG         Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
DEBUG 
DEBUG         By 2026-Feb-18, you need to update your project and remove deprecated calls
DEBUG         or your builds will no longer be supported.
DEBUG 
DEBUG         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
DEBUG         ********************************************************************************
```